### PR TITLE
issue #8, Optimize next_event() function in Trip object updated

### DIFF
--- a/splitinerary/trip.py
+++ b/splitinerary/trip.py
@@ -1,4 +1,5 @@
 import datetime
+import heapq
 from collections import defaultdict
 
 
@@ -92,12 +93,15 @@ class Trip:
             User if it exists, else None.
         """
         now = datetime.datetime.now()
-        all_events = self.get_all_events()
-        for event in all_events:
-            if event.datetime < now:
-                continue
-            return event
-        return None
+        min_heap = []
+        for events in self.dates_dict.values():
+            for event in events:
+                if event.datetime >= now:
+                    heapq.heappush(min_heap, event)
+        if min_heap:
+            return min_heap[0]
+        else:
+            return None
 
     def get_users_list(self):
         """Gets list of users participating in Trip.


### PR DESCRIPTION
I use a min-heap to store events that occur after the current time, npw. By iterating over the dates_dict and each list of events, I add eligible events to the min-heap.

After processing all events, I check if the min-heap is empty. If it's not, the smallest event in the min-heap(the next event) is returned. If the min-heap is empty, None is returned, indicating no upcoming events.

The use of a min-heap reduces the time complexity for finding the next event from linear to logarithmic, improving efficiency. Ensure the correctness of data in self.dates_dict by properly adding events and their dates using the add_event() method.